### PR TITLE
fix not compiled due to make:transitive falg

### DIFF
--- a/src/main/resources/archetype-resources/pom.xml
+++ b/src/main/resources/archetype-resources/pom.xml
@@ -74,7 +74,6 @@
             </goals>
             <configuration>
               <args>
-                <arg>-make:transitive</arg>
                 <arg>-dependencyfile</arg>
                 <arg>${project.build.directory}/.scala_dependencies</arg>
               </args>


### PR DESCRIPTION
When run `mvn compile` was getting -
```
[ERROR] scalac error: bad option: '-make:transitive'
```
this fix it and make compilation to succeed.