### PR TITLE
Switch to scalatest-maven-plugin and fix a dependency declaration problem.

### DIFF
--- a/src/main/resources/archetype-resources/pom.xml
+++ b/src/main/resources/archetype-resources/pom.xml
@@ -44,11 +44,6 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.specs2</groupId>
-      <artifactId>specs2-junit_${scala.compat.version}</artifactId>
-      <version>2.4.16</version>
-    <scope>test</scope>
-    <dependency>
       <groupId>org.scalatest</groupId>
       <artifactId>scalatest_${scala.compat.version}</artifactId>
       <version>2.2.4</version>

--- a/src/main/resources/archetype-resources/pom.xml
+++ b/src/main/resources/archetype-resources/pom.xml
@@ -86,15 +86,27 @@
         <artifactId>maven-surefire-plugin</artifactId>
         <version>2.18.1</version>
         <configuration>
-          <useFile>false</useFile>
-          <disableXmlReport>true</disableXmlReport>
-          <!-- If you have classpath issue like NoDefClassError,... -->
-          <!-- useManifestOnlyJar>false</useManifestOnlyJar -->
-          <includes>
-            <include>**/*Test.*</include>
-            <include>**/*Suite.*</include>
-          </includes>
+          <!-- Tests will be run with scalatest-maven-plugin instead -->
+          <skipTests>true</skipTests>
         </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.scalatest</groupId>
+        <artifactId>scalatest-maven-plugin</artifactId>
+        <version>1.0</version>
+        <configuration>
+          <reportsDirectory>${project.build.directory}/surefire-reports</reportsDirectory>
+          <junitxml>.</junitxml>
+          <filereports>TestSuiteReport.txt</filereports>
+        </configuration>
+        <executions>
+          <execution>
+            <id>test</id>
+            <goals>
+              <goal>test</goal>
+            </goals>
+          </execution>
+        </executions>
       </plugin>
     </plugins>
   </build>


### PR DESCRIPTION
BEFORE:
```
oozie@anonymous:/tmp/maven/abc$ mvn test
[INFO] Scanning for projects...
[ERROR] The build could not read 1 project -> [Help 1]
[ERROR]   
[ERROR]   The project  (/tmp/maven/abc/pom.xml) has 1 error
[ERROR]     Non-parseable POM /tmp/maven/abc/pom.xml: Unrecognised tag: 'dependency' (position: START_TAG seen ...</scope>\n    <dependency>... @50:17)  @ line 50, column 17 -> [Help 2]
[ERROR] 
[ERROR] To see the full stack trace of the errors, re-run Maven with the -e switch.
[ERROR] Re-run Maven using the -X switch to enable full debug logging.
[ERROR] 
[ERROR] For more information about the errors and possible solutions, please read the following articles:
[ERROR] [Help 1] http://cwiki.apache.org/confluence/display/MAVEN/ProjectBuildingException
[ERROR] [Help 2] http://cwiki.apache.org/confluence/display/MAVEN/ModelParseException
```
and after manual correction
```
[...]

-------------------------------------------------------
 T E S T S
-------------------------------------------------------
Running samples.ListSuite
Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.168 sec - in samples.ListSuite
Running samples.MySpecTest
Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.26 sec - in samples.MySpecTest
Running samples.StackSuite
Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.013 sec - in samples.StackSuite
Running samples.AppTest
Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.002 sec - in samples.AppTest

Results :

Tests run: 9, Failures: 0, Errors: 0, Skipped: 0

[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time: 14.541s
[INFO] Finished at: Thu Dec 31 16:57:30 PST 2015
[INFO] Final Memory: 10M/240M
[INFO] ------------------------------------------------------------------------
```

AFTER
```
[INFO] --- scalatest-maven-plugin:1.0:test (test) @ def ---
Discovery starting.
Discovery completed in 222 milliseconds.
Run starting. Expected test count is: 5
ListSuite:
- An empty list should be empty
- A non-empty list should not be empty
- A list's length should equal the number of elements it contains
ExampleSpec:
A Stack
- should pop values in last-in-first-out order
- should throw NoSuchElementException if an empty stack is popped
Run completed in 385 milliseconds.
Total number of tests run: 5
Suites: completed 3, aborted 0
Tests: succeeded 5, failed 0, canceled 0, ignored 0, pending 0
All tests passed.
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time: 2.848s
[INFO] Finished at: Thu Dec 31 16:58:04 PST 2015
[INFO] Final Memory: 11M/303M
[INFO] ------------------------------------------------------------------------
```
