### PR TITLE
upgrade to scala 2.11.8

### DIFF
--- a/src/main/resources/archetype-resources/pom.xml
+++ b/src/main/resources/archetype-resources/pom.xml
@@ -19,7 +19,7 @@
     <maven.compiler.source>1.6</maven.compiler.source>
     <maven.compiler.target>1.6</maven.compiler.target>
     <encoding>UTF-8</encoding>
-    <scala.version>2.11.7</scala.version>
+    <scala.version>2.11.8</scala.version>
     <scala.compat.version>2.11</scala.compat.version>
   </properties>
 


### PR DESCRIPTION
Scala 2.11.8 was released on Tuesday, March 08, 2016 - just updated to recent version.