### PR TITLE
update scala-maven-plugin to 3.2.1

### DIFF
--- a/src/main/resources/archetype-resources/pom.xml
+++ b/src/main/resources/archetype-resources/pom.xml
@@ -65,7 +65,7 @@
         <!-- see http://davidb.github.com/scala-maven-plugin -->
         <groupId>net.alchim31.maven</groupId>
         <artifactId>scala-maven-plugin</artifactId>
-        <version>3.2.0</version>
+        <version>3.2.1</version>
         <executions>
           <execution>
             <goals>


### PR DESCRIPTION
Update scala-maven-plugin to latest version 3.2.1
released on Sunday, June 14, 2015.