### PR TITLE
fix invocation of JUnit(4) tests

### DIFF
--- a/src/main/resources/archetype-resources/pom.xml
+++ b/src/main/resources/archetype-resources/pom.xml
@@ -98,6 +98,8 @@
           <reportsDirectory>${project.build.directory}/surefire-reports</reportsDirectory>
           <junitxml>.</junitxml>
           <filereports>TestSuiteReport.txt</filereports>
+          <!-- Comma separated list of JUnit test class names to execute -->
+          <jUnitClasses>samples.AppTest</jUnitClasses>
         </configuration>
         <executions>
           <execution>


### PR DESCRIPTION
By default `scalatest-maven-plugin` [1] does not discover
JUnit tests. Each JUnit test must be added to a comma
separated list within plugin configuration `jUnitClasses`:

```
<plugin>
  <groupId>org.scalatest</groupId>
  <artifactId>scalatest-maven-plugin</artifactId>
  <version>1.0</version>
  <configuration>
    <reportsDirectory>${project.build.directory}/surefire-reports</reportsDirectory>
    <junitxml>.</junitxml>
    <filereports>TestSuiteReport.txt</filereports>
    <!-- Comma separated list of JUnit test class names to execute -->
    <jUnitClasses>samples.AppTest</jUnitClasses>
  </configuration>
  <executions>
  ...
  </executions>
</plugin>
```

[1] https://github.com/scalatest/scalatest-maven-plugin
