### PR TITLE
Replace deprecated ShouldMatchers with Matchers

### DIFF
--- a/src/main/resources/archetype-resources/src/test/scala/samples/scalatest.scala
+++ b/src/main/resources/archetype-resources/src/test/scala/samples/scalatest.scala
@@ -48,15 +48,15 @@ class StackSuite extends Assertions {
 }
 
 /*
-Here's an example of a FunSuite with ShouldMatchers mixed in:
+Here's an example of a FunSuite with Matchers mixed in:
 */
 import org.scalatest.FunSuite
-import org.scalatest.matchers.ShouldMatchers
+import org.scalatest.Matchers
 
 import org.junit.runner.RunWith
 import org.scalatest.junit.JUnitRunner
 @RunWith(classOf[JUnitRunner])
-class ListSuite extends FunSuite with ShouldMatchers {
+class ListSuite extends FunSuite with Matchers {
 
   test("An empty list should be empty") {
     List() should be ('empty)


### PR DESCRIPTION
Fixes the warning below:

```
[INFO] Compiling 3 source files to /Users/bhamail/sonatype/support/scala/archetype/myartifact/target/test-classes at 1482460576204
[WARNING] /Users/bhamail/sonatype/support/scala/archetype/myartifact/src/test/scala/samples/scalatest.scala:59: warning: trait ShouldMatchers in package matchers is deprecated: Please use org.scalatest.Matchers instead.
[WARNING] class ListSuite extends FunSuite with ShouldMatchers {
[WARNING]                                       ^
[WARNING] one warning found
```